### PR TITLE
feat: auto-detect CSV encoding

### DIFF
--- a/strategy_test.py
+++ b/strategy_test.py
@@ -5,9 +5,21 @@ import numpy as np
 from pathlib import Path
 import argparse
 from datetime import datetime
+import codecs
 
 
 def load_data(filepath: str, encoding: str) -> pd.DataFrame:
+    """Load CSV data with optional encoding auto-detection."""
+    if encoding == 'auto':
+        with open(filepath, 'rb') as f:
+            start = f.read(4)
+        if start.startswith(codecs.BOM_UTF16_LE) or start.startswith(codecs.BOM_UTF16_BE):
+            encoding = 'utf-16'
+        elif start.startswith(codecs.BOM_UTF8):
+            encoding = 'utf-8-sig'
+        else:
+            encoding = 'utf-8'
+
     df = pd.read_csv(
         filepath,
         names=["time", "open", "high", "low", "close", "tick_volume", "real_volume"],
@@ -124,8 +136,8 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--encoding',
-        default='utf-8',
-        help='File encoding for CSV files (default: utf-8)',
+        default='auto',
+        help='File encoding for CSV files or "auto" to detect (default: auto)',
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- add BOM-based encoding detection for CSV imports
- allow `--encoding auto` to automatically choose CSV encoding

## Testing
- `python strategy_test.py --file EURUSDM5.csv EURUSDM15.csv EURUSDM30.csv EURUSDH1.csv EURUSDH4.csv EURUSDDaily.csv EURUSDWeekly.csv EURUSDMonthly.csv --tf M5 M15 M30 H1 H4 D1 W1 MN`


------
https://chatgpt.com/codex/tasks/task_e_688fcb81f3c8832c9a0d5ec80c33fa66