### PR TITLE
Handle ZigZag init errors in GetLastPivot

### DIFF
--- a/MasterForex_Pivot_my_v8.mq5
+++ b/MasterForex_Pivot_my_v8.mq5
@@ -117,10 +117,23 @@ double GetLastPivot(string symbol, ENUM_TIMEFRAMES tf, int &handle)
         }
      }
 
+   int bars = BarsCalculated(handle);
+   if(bars <= 0)
+     {
+      Print("BarsCalculated ZigZag tf=", tf, " result=", bars, " err=", GetLastError());
+      return 0.0;
+     }
+
    double zzBuffer[];
    if(CopyBuffer(handle, 0, 0, 200, zzBuffer) <= 0)
      {
-      Print("CopyBuffer ZigZag failed tf=", tf, " err=", GetLastError());
+      int err = GetLastError();
+      Print("CopyBuffer ZigZag failed tf=", tf, " err=", err);
+      if(err != 0)
+        {
+         IndicatorRelease(handle);
+         handle = INVALID_HANDLE;
+        }
       return 0.0;
      }
 


### PR DESCRIPTION
## Summary
- Guard ZigZag access with BarsCalculated() to ensure data availability
- Release ZigZag handle on CopyBuffer errors so it can reinitialize cleanly

## Testing
- `python strategy_test.py --file EURUSDH1.csv --tf H1`


------
https://chatgpt.com/codex/tasks/task_e_68926a52d5c4832c8ce87e90fecab91b