### PR TITLE
Set default 30‑pip profit threshold in tests

### DIFF
--- a/results.txt
+++ b/results.txt
@@ -57,3 +57,35 @@ Signals: 642
 Success rate: 81.62%
 2025-08-05T21:13:04+00:00
 
+2025-08-05T21:55:49.201919
+File: EURUSDM5.csv | TF: M5
+Signals: 99923
+Success rate: 2.08% (>0.003)
+2025-08-05T21:56:07.486581
+File: EURUSDM15.csv | TF: M15
+Signals: 99890
+Success rate: 8.04% (>0.003)
+2025-08-05T21:56:26.056625
+File: EURUSDM30.csv | TF: M30
+Signals: 100176
+Success rate: 14.91% (>0.003)
+2025-08-05T21:56:44.808840
+File: EURUSDH1.csv | TF: H1
+Signals: 100026
+Success rate: 31.88% (>0.003)
+2025-08-05T21:56:53.672764
+File: EURUSDH4.csv | TF: H4
+Signals: 48308
+Success rate: 59.61% (>0.003)
+2025-08-05T21:56:56.107767
+File: EURUSDDaily.csv | TF: D1
+Signals: 14000
+Success rate: 71.44% (>0.003)
+2025-08-05T21:56:56.630152
+File: EURUSDWeekly.csv | TF: W1
+Signals: 2828
+Success rate: 78.29% (>0.003)
+2025-08-05T21:56:56.757022
+File: EURUSDMonthly.csv | TF: MN
+Signals: 642
+Success rate: 80.37% (>0.003)


### PR DESCRIPTION
## Summary
- default to 30‑pip (0.0030) profit threshold in backtests
- add CLI option to override threshold per run

## Testing
- `python strategy_test.py --file EURUSDM5.csv EURUSDM15.csv EURUSDM30.csv EURUSDH1.csv EURUSDH4.csv EURUSDDaily.csv EURUSDWeekly.csv EURUSDMonthly.csv --tf M5 M15 M30 H1 H4 D1 W1 MN`


------
https://chatgpt.com/codex/tasks/task_e_68927d2a25fc832cb177bc998a7cf323