### PR TITLE
Integrate ZigZag and add multi-timeframe tester

### DIFF
--- a/MasterForex_Pivot_my_v82308.mq5
+++ b/MasterForex_Pivot_my_v82308.mq5
@@ -1,0 +1,328 @@
+//+------------------------------------------------------------------+
+//| MasterForex-V MultiTF Indicator v8.2308                          |
+//| Индикатор с подтверждёнными MF-pivot и дополнительными сигналами |
+//+------------------------------------------------------------------+
+#property indicator_chart_window
+#property indicator_buffers 6
+#property indicator_plots   6
+
+input bool   UseRussian = false;              // подписи на русском языке
+
+//--- Buy arrow / Стрелка покупки
+#property indicator_label1  "BuyArrow"
+#property indicator_type1   DRAW_ARROW
+#property indicator_color1  clrLime
+#property indicator_style1  STYLE_SOLID
+#property indicator_width1  2
+
+//--- Sell arrow / Стрелка продажи
+#property indicator_label2  "SellArrow"
+#property indicator_type2   DRAW_ARROW
+#property indicator_color2  clrRed
+#property indicator_style2  STYLE_SOLID
+#property indicator_width2  2
+
+//--- Buffers for various signals / Буферы сигналов
+double BuyArrowBuffer[];    // сильный сигнал покупки
+double SellArrowBuffer[];   // сильный сигнал продажи
+double EarlyBuyBuffer[];    // ранний вход покупка
+double EarlySellBuffer[];   // ранний вход продажа
+double ExitBuffer[];        // крестик выхода
+double ReverseBuffer[];     // метка разворота
+
+//--- For new levels on H4 and D1 / Для H4 и D1 новых уровней
+double mfPivotH4;
+double mfPivotD1;
+
+//--- Classic Pivot levels / Классические уровни Pivot
+double pivotLevel, r1Level, r2Level, s1Level, s2Level;
+
+//--- Objects for classic Pivot lines / Объекты для линий классических Pivot
+string objPivot = "MF_ClassicPivot";
+string objR1    = "MF_ClassicR1";
+string objR2    = "MF_ClassicR2";
+string objS1    = "MF_ClassicS1";
+string objS2    = "MF_ClassicS2";
+
+//--- ZigZag settings
+int    InpDepth    = 12;       // Depth
+double InpDeviation = 5*_Point; // Deviation in price
+
+//+------------------------------------------------------------------+
+//| Initialization / Инициализация                                   |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   SetIndexBuffer(0, BuyArrowBuffer,   INDICATOR_DATA);
+   SetIndexBuffer(1, SellArrowBuffer,  INDICATOR_DATA);
+   SetIndexBuffer(2, EarlyBuyBuffer,   INDICATOR_DATA);
+   SetIndexBuffer(3, EarlySellBuffer,  INDICATOR_DATA);
+   SetIndexBuffer(4, ExitBuffer,       INDICATOR_DATA);
+   SetIndexBuffer(5, ReverseBuffer,    INDICATOR_DATA);
+
+   ArraySetAsSeries(BuyArrowBuffer,   true);
+   ArraySetAsSeries(SellArrowBuffer,  true);
+   ArraySetAsSeries(EarlyBuyBuffer,   true);
+   ArraySetAsSeries(EarlySellBuffer,  true);
+   ArraySetAsSeries(ExitBuffer,       true);
+   ArraySetAsSeries(ReverseBuffer,    true);
+
+   IndicatorSetString(INDICATOR_SHORTNAME, "MasterForex-V MultiTF v8.2308");
+
+   PlotIndexSetInteger(0, PLOT_ARROW, 233); // up arrow
+   PlotIndexSetInteger(1, PLOT_ARROW, 234); // down arrow
+   PlotIndexSetInteger(2, PLOT_ARROW, 241); // early up
+   PlotIndexSetInteger(3, PLOT_ARROW, 242); // early down
+   PlotIndexSetInteger(4, PLOT_ARROW, 251); // cross exit
+   PlotIndexSetInteger(5, PLOT_ARROW, 221); // reversal mark
+
+   PlotIndexSetInteger(0, PLOT_LINE_COLOR, clrLime);
+   PlotIndexSetInteger(1, PLOT_LINE_COLOR, clrRed);
+   PlotIndexSetInteger(2, PLOT_LINE_COLOR, clrLime);
+   PlotIndexSetInteger(3, PLOT_LINE_COLOR, clrRed);
+   PlotIndexSetInteger(4, PLOT_LINE_COLOR, clrGray);
+   PlotIndexSetInteger(5, PLOT_LINE_COLOR, clrAqua);
+
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Deinitialization / Деинициализация                               |
+//+------------------------------------------------------------------+
+void OnDeinit(const int reason)
+  {
+  }
+
+//+------------------------------------------------------------------+
+//| Retrieve last ZigZag extremum (MF-pivot)                         |
+//+------------------------------------------------------------------+
+double GetLastPivot(string symbol, ENUM_TIMEFRAMES tf)
+  {
+   int bars = iBars(symbol, tf);
+   if(bars < InpDepth + 2)
+      return 0.0;
+
+   int count = MathMin(bars, 300);
+   double close[];
+   if(CopyClose(symbol, tf, 0, count, close) <= 0)
+      return 0.0;
+   ArraySetAsSeries(close, true);
+
+   double last_pivot_price = close[count-1];
+   int direction = 0;
+   for(int i = count-2; i >= 0; --i)
+     {
+      double price = close[i];
+      if(direction == 0)
+        {
+         if(MathAbs(price - last_pivot_price) > InpDeviation)
+           {
+            direction = (price > last_pivot_price) ? 1 : -1;
+            last_pivot_price = price;
+           }
+        }
+      else if(direction == 1)
+        {
+         if(price > last_pivot_price)
+            last_pivot_price = price;
+         else if((last_pivot_price - price) > InpDeviation)
+            return last_pivot_price;
+        }
+      else // direction == -1
+        {
+         if(price < last_pivot_price)
+            last_pivot_price = price;
+         else if((price - last_pivot_price) > InpDeviation)
+            return last_pivot_price;
+        }
+     }
+   return last_pivot_price;
+  }
+
+//+------------------------------------------------------------------+
+//| Determine trend                                                  |
+//+------------------------------------------------------------------+
+int GetTrend(double price, double pivot, double tol=0.0001)
+  {
+   if(price > pivot + tol) return 1;
+   if(price < pivot - tol) return -1;
+   return 0;
+  }
+
+//+------------------------------------------------------------------+
+//| Calculate classic Pivot levels                                   |
+//+------------------------------------------------------------------+
+void CalculateClassicPivotLevels(string symbol, ENUM_TIMEFRAMES tf)
+  {
+   double high  = iHigh(symbol, tf, 1);
+   double low   = iLow(symbol, tf, 1);
+   double close = iClose(symbol, tf, 1);
+
+   pivotLevel = (high + low + close) / 3.0;
+   r1Level    = 2 * pivotLevel - low;
+   s1Level    = 2 * pivotLevel - high;
+   r2Level    = pivotLevel + (high - low);
+   s2Level    = pivotLevel - (high - low);
+  }
+
+//+------------------------------------------------------------------+
+//| Draw or update horizontal line                                   |
+//+------------------------------------------------------------------+
+void DrawOrUpdateLine(string name, double price, color clr, int width=1, ENUM_LINE_STYLE style=STYLE_DOT)
+  {
+   if(ObjectFind(0, name) < 0)
+     {
+      ObjectCreate(0, name, OBJ_HLINE, 0, 0, price);
+      ObjectSetInteger(0, name, OBJPROP_COLOR, clr);
+      ObjectSetInteger(0, name, OBJPROP_WIDTH, width);
+      ObjectSetInteger(0, name, OBJPROP_STYLE, style);
+      ObjectSetInteger(0, name, OBJPROP_BACK, true);
+      ObjectSetInteger(0, name, OBJPROP_SELECTABLE, false);
+     }
+   else
+     {
+      ObjectSetDouble(0, name, OBJPROP_PRICE, price);
+     }
+  }
+
+//+------------------------------------------------------------------+
+//| Draw single status row                                           |
+//+------------------------------------------------------------------+
+void DrawRowLabel(string name, string text, int y)
+  {
+   if(ObjectFind(0, name) < 0)
+     {
+      ObjectCreate(0, name, OBJ_LABEL, 0, 0, 0);
+      ObjectSetInteger(0, name, OBJPROP_CORNER, 0);
+      ObjectSetInteger(0, name, OBJPROP_XDISTANCE, 10);
+      ObjectSetInteger(0, name, OBJPROP_YDISTANCE, y);
+      ObjectSetInteger(0, name, OBJPROP_FONTSIZE, 14);
+      ObjectSetInteger(0, name, OBJPROP_COLOR, clrWhite);
+      ObjectSetInteger(0, name, OBJPROP_BACK, false);
+     }
+   ObjectSetString(0, name, OBJPROP_TEXT, text);
+  }
+
+//+------------------------------------------------------------------+
+//| Main calculation                                                 |
+//+------------------------------------------------------------------+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const int begin,
+                const double &price[])
+  {
+   ArraySetAsSeries(price, true);
+   ArrayResize(BuyArrowBuffer,   rates_total);
+   ArrayResize(SellArrowBuffer,  rates_total);
+   ArrayResize(EarlyBuyBuffer,   rates_total);
+   ArrayResize(EarlySellBuffer,  rates_total);
+   ArrayResize(ExitBuffer,       rates_total);
+   ArrayResize(ReverseBuffer,    rates_total);
+
+   BuyArrowBuffer[0]   = EMPTY_VALUE;
+   SellArrowBuffer[0]  = EMPTY_VALUE;
+   EarlyBuyBuffer[0]   = EMPTY_VALUE;
+   EarlySellBuffer[0]  = EMPTY_VALUE;
+   ExitBuffer[0]       = EMPTY_VALUE;
+   ReverseBuffer[0]    = EMPTY_VALUE;
+
+   double price_now = price[0];
+
+   static int    lastSignal   = 0;
+   static double lastPivot    = 0.0;
+   static int    lastTrendH1  = 0;
+   static int    lastTrendM15 = 0;
+
+   double pivotH1  = GetLastPivot(_Symbol, PERIOD_H1);
+   double pivotM15 = GetLastPivot(_Symbol, PERIOD_M15);
+   double pivotM5  = GetLastPivot(_Symbol, PERIOD_M5);
+
+   mfPivotH4 = GetLastPivot(_Symbol, PERIOD_H4);
+   mfPivotD1 = GetLastPivot(_Symbol, PERIOD_D1);
+
+   if(pivotH1 == 0.0 || pivotM15 == 0.0 || pivotM5 == 0.0)
+     {
+      Print("Pivots unavailable, skipping signals");
+      return(rates_total);
+     }
+
+   int trendH1  = GetTrend(price_now, pivotH1);
+   int trendM15 = GetTrend(price_now, pivotM15);
+   int trendM5  = GetTrend(price_now, pivotM5);
+
+   string strH1  = trendH1 > 0  ? "↑" : (trendH1 < 0  ? "↓" : "-");
+   string strM15 = trendM15 > 0 ? "↑" : (trendM15 < 0 ? "↓" : "-");
+   string strM5  = trendM5 > 0  ? "↑" : (trendM5 < 0  ? "↓" : "-");
+   string trendFmt = UseRussian ? "Тренд H1: %s  M15: %s  M5: %s"
+                                : "Trend H1: %s  M15: %s  M5: %s";
+   string trendStatus = StringFormat(trendFmt, strH1, strM15, strM5);
+
+   string pivotWord = UseRussian ? "Пивот" : "Pivot";
+   string levelM5  = StringFormat("%s M5: %s",  pivotWord, DoubleToString(pivotM5,  _Digits));
+   string levelM15 = StringFormat("%s M15: %s", pivotWord, DoubleToString(pivotM15, _Digits));
+   string levelH1  = StringFormat("%s H1: %s",  pivotWord, DoubleToString(pivotH1,  _Digits));
+   string levelH4  = StringFormat("%s H4: %s",  pivotWord, DoubleToString(mfPivotH4,_Digits));
+   string levelD1  = StringFormat("%s D1: %s",  pivotWord, DoubleToString(mfPivotD1,_Digits));
+
+   DrawRowLabel("MFV_STATUS_TREND", trendStatus, 10);
+   DrawRowLabel("MFV_STATUS_M5",    levelM5,     30);
+   DrawRowLabel("MFV_STATUS_M15",   levelM15,    50);
+   DrawRowLabel("MFV_STATUS_H1",    levelH1,     70);
+   DrawRowLabel("MFV_STATUS_H4",    levelH4,     90);
+   DrawRowLabel("MFV_STATUS_D1",    levelD1,     110);
+
+   if(trendH1 == 1 && trendM15 == 1 && trendM5 == 1)
+     {
+      BuyArrowBuffer[1] = price[1] - 10 * _Point;
+      lastSignal = 1;
+      lastPivot  = pivotH1;
+     }
+   else if(trendH1 == -1 && trendM15 == -1 && trendM5 == -1)
+     {
+      SellArrowBuffer[1] = price[1] + 10 * _Point;
+      lastSignal = -1;
+      lastPivot  = pivotH1;
+     }
+   else if(trendH1 == 1 && trendM5 == 1 && trendM15 != 1)
+     {
+      EarlyBuyBuffer[1] = price[1] - 10 * _Point;
+     }
+   else if(trendH1 == -1 && trendM5 == -1 && trendM15 != -1)
+     {
+      EarlySellBuffer[1] = price[1] + 10 * _Point;
+     }
+
+   if(lastSignal == 1 && price_now < lastPivot)
+     {
+      ExitBuffer[1] = price[1];
+      lastSignal = 0;
+     }
+   else if(lastSignal == -1 && price_now > lastPivot)
+     {
+      ExitBuffer[1] = price[1];
+      lastSignal = 0;
+     }
+
+   if(trendH1 == trendM15 && trendH1 != 0 && trendH1 != lastTrendH1 && lastTrendH1 != 0)
+     {
+      ReverseBuffer[1] = price[1];
+     }
+   lastTrendH1  = trendH1;
+   lastTrendM15 = trendM15;
+
+   DrawOrUpdateLine("MF_PIVOT_H1",  pivotH1,  clrBlue,     2);
+   DrawOrUpdateLine("MF_PIVOT_M15", pivotM15, clrGreen,    1);
+   DrawOrUpdateLine("MF_PIVOT_M5",  pivotM5,  clrOrange,   1);
+   DrawOrUpdateLine("MF_PIVOT_H4",  mfPivotH4, clrMagenta, 1, STYLE_DASH);
+   DrawOrUpdateLine("MF_PIVOT_D1",  mfPivotD1, clrDimGray, 1, STYLE_DASH);
+
+   CalculateClassicPivotLevels(_Symbol, PERIOD_D1);
+   DrawOrUpdateLine(objPivot, pivotLevel, clrYellow,     2, STYLE_SOLID);
+   DrawOrUpdateLine(objR1,    r1Level,    clrDodgerBlue, 1, STYLE_DOT);
+   DrawOrUpdateLine(objR2,    r2Level,    clrDodgerBlue, 1, STYLE_DOT);
+   DrawOrUpdateLine(objS1,    s1Level,    clrOrange,     1, STYLE_DOT);
+   DrawOrUpdateLine(objS2,    s2Level,    clrOrange,     1, STYLE_DOT);
+
+   return(rates_total);
+  }
+//+------------------------------------------------------------------+

--- a/strategy_test_v82308.py
+++ b/strategy_test_v82308.py
@@ -1,0 +1,167 @@
+# strategy_test_v82308.py
+# Multi-timeframe backtest with integrated ZigZag confirmation
+# Version 8.2308
+
+# Usage example:
+# python strategy_test_v82308.py --file EURUSDM5.csv EURUSDM15.csv EURUSDH1.csv --tf M5 M15 H1
+
+import pandas as pd
+import numpy as np
+from pathlib import Path
+import argparse
+from datetime import datetime
+import codecs
+
+__version__ = "8.2308"
+
+
+def load_data(filepath: str, encoding: str) -> pd.DataFrame:
+    """Load CSV data with optional encoding auto-detection."""
+    if encoding == 'auto':
+        with open(filepath, 'rb') as f:
+            start = f.read(4)
+        if start.startswith(codecs.BOM_UTF16_LE) or start.startswith(codecs.BOM_UTF16_BE):
+            encoding = 'utf-16'
+        elif start.startswith(codecs.BOM_UTF8):
+            encoding = 'utf-8-sig'
+        else:
+            encoding = 'utf-8'
+
+    df = pd.read_csv(
+        filepath,
+        names=["time", "open", "high", "low", "close", "tick_volume", "real_volume"],
+        parse_dates=["time"],
+        encoding=encoding,
+    )
+    df.sort_values('time', inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def zigzag(df: pd.DataFrame, deviation: float = 0.0005) -> pd.DataFrame:
+    pivots = []
+    last_pivot_price = df['close'].iloc[0]
+    last_pivot_idx = 0
+    direction = 0
+    for i, price in enumerate(df['close']):
+        if direction == 0:
+            if abs(price - last_pivot_price) > deviation:
+                direction = 1 if price > last_pivot_price else -1
+                last_pivot_price = price
+                last_pivot_idx = i
+                pivots.append((i, price))
+        elif direction == 1:
+            if price > last_pivot_price:
+                last_pivot_price = price
+                last_pivot_idx = i
+            elif (last_pivot_price - price) > deviation:
+                pivots.append((last_pivot_idx, last_pivot_price))
+                direction = -1
+                last_pivot_price = price
+                last_pivot_idx = i
+        else:
+            if price < last_pivot_price:
+                last_pivot_price = price
+                last_pivot_idx = i
+            elif (price - last_pivot_price) > deviation:
+                pivots.append((last_pivot_idx, last_pivot_price))
+                direction = 1
+                last_pivot_price = price
+                last_pivot_idx = i
+
+    pivots.append((last_pivot_idx, last_pivot_price))
+    df['pivot'] = np.nan
+    for idx, price in pivots:
+        df.at[idx, 'pivot'] = price
+
+    # Trend
+    df['trend'] = 0
+    last_pivot = pivots[0][1]
+    last_idx = pivots[0][0]
+    for i in range(len(df)):
+        if i > last_idx and not np.isnan(df['pivot'].iloc[i - 1]):
+            last_idx = i - 1
+            last_pivot = df['pivot'].iloc[i - 1]
+        price = df['close'].iloc[i]
+        if price > last_pivot:
+            df.at[i, 'trend'] = 1
+        elif price < last_pivot:
+            df.at[i, 'trend'] = -1
+        else:
+            df.at[i, 'trend'] = 0
+    return df
+
+
+def evaluate_signals_multi(dfs: list[pd.DataFrame], look_ahead: int = 12, threshold: float = 0.0030) -> tuple[int, float]:
+    base = dfs[0][['time', 'close', 'trend']].rename(columns={'trend': 'trend0'})
+    for i, df in enumerate(dfs[1:], start=1):
+        base = pd.merge_asof(
+            base,
+            df[['time', 'trend']].rename(columns={'trend': f'trend{i}'}),
+            on='time',
+            direction='backward',
+        )
+
+    trend_cols = [f'trend{i}' for i in range(len(dfs))]
+    base['signal'] = np.where(base[trend_cols].eq(1).all(axis=1), 'BUY',
+                       np.where(base[trend_cols].eq(-1).all(axis=1), 'SELL', None))
+
+    results = []
+    for idx, row in base.dropna(subset=['signal']).iterrows():
+        price = row['close']
+        future = base['close'].iloc[idx+1: idx+1+look_ahead]
+        if len(future) < look_ahead:
+            continue
+        if row['signal'] == 'BUY':
+            success = (future.max() - price) >= threshold
+        else:
+            success = (price - future.min()) >= threshold
+        results.append(success)
+
+    success_rate = (sum(results) / len(results) * 100) if results else 0.0
+    return len(results), success_rate
+
+
+def run(files: list[str], tf_labels: list[str], encoding: str):
+    dfs = []
+    for fp in files:
+        df = load_data(fp, encoding)
+        df = zigzag(df)
+        dfs.append(df)
+
+    count, success = evaluate_signals_multi(dfs)
+    msg = (
+        "Files: " + ", ".join(Path(f).name for f in files) + '\n' +
+        "TFs: " + ", ".join(tf_labels) + '\n' +
+        f"Signals: {count}\nSuccess rate: {success:.2f}%"
+    )
+    print(msg)
+    timestamp = datetime.now().isoformat()
+    with open("results.txt", "a", encoding="utf-8") as f:
+        f.write(f"{timestamp}\n{msg}\n")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Multi-timeframe ZigZag trend strategy test."
+    )
+    parser.add_argument(
+        '--file',
+        required=True,
+        nargs=3,
+        help='Three CSV files with historical data for different timeframes',
+    )
+    parser.add_argument(
+        '--tf',
+        nargs=3,
+        help='Labels of the timeframes (e.g., M5 M15 H1)',
+    )
+    parser.add_argument(
+        '--encoding',
+        default='auto',
+        help='File encoding for CSV files or "auto" to detect (default: auto)',
+    )
+    args = parser.parse_args()
+
+    tf_list = args.tf if args.tf else [Path(fp).stem for fp in args.file]
+    run(args.file, tf_list, args.encoding)


### PR DESCRIPTION
## Summary
- Embed ZigZag logic directly into the MasterForex indicator and version it as v8.2308 to remove external dependency.
- Add a Python backtester (v8.2308) that confirms trends across three timeframes with a default 30‑pip take-profit.

## Testing
- `python strategy_test_v82308.py --file EURUSDM5.csv EURUSDM15.csv EURUSDH1.csv --tf M5 M15 H1`


------
https://chatgpt.com/codex/tasks/task_e_68928e698764832c8e1c9e61aaf44f44